### PR TITLE
Use valid XDG category

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "category": "music"
     },
     "linux": {
-      "category": "music",
+      "category": "AudioVideo",
       "target": [
         "AppImage"
       ]


### PR DESCRIPTION
Closes https://github.com/filipuic/playme/issues/7

According to the [menu spec](https://standards.freedesktop.org/menu-spec/latest/apa.html),

> By including one of the Main Categories in an application's desktop entry file, the application will be ensured that it will show up in a section of the application menu dedicated to this category. If multiple Main Categories are included in a single desktop entry file, the entry may appear more than once in the menu. 

Hence, please add at least one of the following in the `Categories=` key.

Main Category | Description | Notes
-- | -- | --
AudioVideo | Application for presenting, creating, or processing multimedia (audio/video) |  
Audio | An audio application | Desktop entry must include AudioVideo as well
Video | A video application | Desktop entry must include AudioVideo as well
Development | An application for development |  
Education | Educational software |  
Game | A game |  
Graphics | Application for viewing, creating, or processing graphics |  
Network | Network application such as a web browser |  
Office | An office type application |  
Science | Scientific software |  
Settings | Settings applications | Entries may appear in a separate menu or as part of a 		"Control Center"
System | System application, "System Tools" such as say a log viewer or network monitor |  
Utility | Small utility application, "Accessories"
